### PR TITLE
jython module for custom constraints, refactoring

### DIFF
--- a/conf/default.cfg
+++ b/conf/default.cfg
@@ -1,7 +1,7 @@
 [stanford]
 dir = /home/recski/projects/stanford_dp/stanford-parser-full-2015-01-30
 parser = stanford-parser.jar
-model = englishPCFG.ser.gz
+model = englishRNN.ser.gz
 jython = /home/recski/projects/jython/jython
 
 [data]

--- a/conf/default.cfg
+++ b/conf/default.cfg
@@ -1,5 +1,8 @@
 [stanford]
-stanford_dir = /home/recski/projects/stanford_dp/stanford-parser-full-2015-01-30
+dir = /home/recski/projects/stanford_dp/stanford-parser-full-2015-01-30
+parser = stanford-parser.jar
+model = englishPCFG.ser.gz
+jython = /home/recski/projects/jython/jython
 
 [data]
 tmp_dir = data/tmp

--- a/eval/roots.rand100
+++ b/eval/roots.rand100
@@ -1,0 +1,100 @@
+strategist	good	person	good at planning things, especially military or political actions
+unlikely	not		not likely to happen
+digger	machine		a large machine that digs and moves earth
+jolt	shock		a sudden shock
+locution	style		a style of speaking
+well	comes		if a liquid wells or wells up, it comes to the surface of something and starts to flow out
+non-toxic	not		not poisonous or harmful to your health
+stead	do		to do something that someone else usually does or was going to do
+spoof	book		a funny book, play, or film that copies something serious or important and makes it seem silly
+seaward	facing		facing towards the sea
+!much-heralded	event		a much-heralded event, product, etc has been talked about a lot before it happens or becomes available
+incessant	continuing		continuing without stopping
+!politico-	relating		relating to both politics and something else
+chord	combination		a combination of several musical notes that are played at the same time and sound pleasant together
+woeful	bad		very bad or serious
+rattler	rattlesnake		a rattlesnake
+!blockade	put		to put a place under a blockade
+squadron	force		a military force consisting of a group of aircraft or ships
+little	slightly		slightly or to a small degree
+elf	creature		an imaginary creature like a small person with pointed ears and magical powers
+!med	abbreviation		an abbreviation of medical
+stepladder	flat		a ladder which has two sloping parts that are joined at the top so that it can stand without support, and which can be folded flat
+well-fed	having		having plenty of good food to eat
+sensation	feeling		a feeling that you get from one of your five senses, especially the sense of touch
+rouse	wake	person	to wake sleeping deeply
+provoke	cause		to cause a reaction or feeling, especially a sudden one
+plagiarize	take		to take words or ideas from another person's work and use them in your work, without stating that they are not your own
+rephrase	say		to say or write something again using different words to express what you mean in a way that is clearer or more acceptable
+eyeliner	make-up		coloured make-up that you put along the edges of your eyelids to make your eyes look bigger or more noticeable
+liquor	drink		a strong alcoholic drink such as whisky
+donkeywork	work		the hard boring work that is part of a job or project
+velocity	speed		the speed of something that is moving in a particular direction
+onlooker	watches	person	watches something happening without being involved in it
+!sweatshop	used		a small business, factory, etc where people work hard in bad conditions for very little money - used to show disapproval
+!suffering	physical		serious physical or mental pain
+!OD	take		to take too much of a drug so that it is dangerous
+blithe	seeming		seeming not to care or worry about the effects of what you do
+!nocturnal	active		an animal that is nocturnal is active at night
+!reciprocate	do		to do or give something, because something similar has been done or given to you
+S	letter		the 19th letter of the English alphabet
+situate	describe		to describe or consider something as being part of something else or related to something else
+steal	cheap		to be very cheap
+bibliography	list		a list of all the books and articles used in preparing a piece of writing
+abomination	something	person	or something that is extremely offensive or unacceptable
+stem	stop		to stop something from happening, spreading, or developing
+jovial	friendly		friendly and happy
+!starlit	made		made brighter by light from the stars
+hereinafter	later		later in this official statement, document, etc
+oracular	from		from or like an oracle
+overwhelm	feel		if someone is overwhelmed by an emotion, they feel it so strongly that they cannot think clearly
+stud	use		the use of animals, especially horses, for breeding, an animal that is used in this way, or a place where this is done
+!dutiable	those		dutiable goods are those that you must pay duty on
+bike	ride		to ride a bicycle
+sundress	dress		a dress that you wear in hot weather, which does not cover your arms or shoulders
+!hamburger	cut		a flat round piece of finely cut beef which is cooked and eaten in a bread bun
+tanker	vehicle		a vehicle or ship specially built to carry large quantities of gas or liquid, especially oil
+harsh	difficult		harsh conditions are difficult to live in and very uncomfortable
+extinguisher	extinguisher		a fire extinguisher
+!impure	pure		not pure or clean, and often consisting of a mixture of things instead of just one
+!madden	make		to make someone very angry or annoyed
+huff	feeling		feeling angry or bad-tempered, especially because someone has offended you
+!ill-equipped	having		not having the necessary equipment or skills for a particular situation or activity
+settler	goes	person	goes to live in a country or area where not many people like them have lived before, and that is a long way from any towns or cities
+outdid	past		the past tense of outdo
+stepmother	woman		a woman who is married to your father but who is not your mother
+effrontery	rude		rude behaviour that shocks you because it is so confident
+!parasol	type		a type of umbrella used to provide shade from the sun
+food	things		things that people and animals eat, such as vegetables or meat
+roll	piece		a piece of paper, camera film, money, etc that has been rolled into the shape of a tube
+!hood	pull		a part of a coat, jacket, etc that you can pull up to cover your head
+!kohl	eyes		a black pencil used around women's eyes to make them more attractive
+!ballyhoo	is		when there is a lot of excitement or anger about something - used to show disapproval
+macho	behaving		behaving in a way that is traditionally typical of men, for example being strong or brave, or not showing your feelings - used humorously or in order to show disapproval
+birdbath	bowl		a bowl in a garden that is filled with water for birds to wash in
+stockbroker	person		a person or organization whose job is to buy and sell shares , bonds, etc for people
+!tarot	set		a set of 78 cards, used for telling what will happen to someone in the future
+krill	shellfish		small shellfish
+!inflammable	start		inflammable materials or substances will start to burn very easily
+storeroom	room		a room where goods are stored
+Turk	from	person	from Turkey
+!wide	open		completely open, awake, or apart
+!freephone	arrangement		an arrangement by which a company or organization pays the cost of telephone calls made to it
+!impressive	makes		something that is impressive makes you admire it because it is very good, large, important, etc
+long-lived	living		living or existing for a long time
+negotiate	discuss		to discuss something in order to reach an agreement, especially in business or politics
+!tempting	seems		something that is tempting seems very good and you would like to have it or do it
+revue	show		a show in a theatre that includes songs, dances, and jokes about recent events
+!subhuman	having		not having all the qualities a normal human being has
+winsome	behaving		behaving in a pleasant and attractive way
+!capP	abbreviation		the abbreviation of
+ornamentation	decoration		decoration on an object that makes it look attractive
+cowrie	shell		a small shiny shell that was used in the past as money in parts of Africa and Asia
+belongings	things		the things you own, especially things that you can carry with you
+bonfire	fire		a large outdoor fire, either for burning waste or for a party
+hearth	area		the area of floor around a fireplace in a house
+ultra-	extremely		extremely
+dispossess	take		to take property or land away from someone
+poodle	dog		a dog with thick curly hair
+feminism	belief		the belief that women should have the same rights and opportunities as men
+advertorial	advertisement		an advertisement in a newspaper or magazine that is made to look like a normal article

--- a/eval/roots.rand100.issues
+++ b/eval/roots.rand100.issues
@@ -1,0 +1,27 @@
+!much-heralded	event		a much-heralded event, product, etc has been talked about a lot before it happens or becomes available
+!politico-	relating		relating to both politics and something else
+!blockade	put		to put a place under a blockade
+!med	abbreviation		an abbreviation of medical
+!sweatshop	used		a small business, factory, etc where people work hard in bad conditions for very little money - used to show disapproval
+!suffering	physical		serious physical or mental pain
+!OD	take		to take too much of a drug so that it is dangerous
+!nocturnal	active		an animal that is nocturnal is active at night
+!reciprocate	do		to do or give something, because something similar has been done or given to you
+!starlit	made		made brighter by light from the stars
+!dutiable	those		dutiable goods are those that you must pay duty on
+!hamburger	cut		a flat round piece of finely cut beef which is cooked and eaten in a bread bun
+!impure	pure		not pure or clean, and often consisting of a mixture of things instead of just one
+!madden	make		to make someone very angry or annoyed
+!ill-equipped	having		not having the necessary equipment or skills for a particular situation or activity
+!parasol	type		a type of umbrella used to provide shade from the sun
+!hood	pull		a part of a coat, jacket, etc that you can pull up to cover your head
+!kohl	eyes		a black pencil used around women's eyes to make them more attractive
+!ballyhoo	is		when there is a lot of excitement or anger about something - used to show disapproval
+!tarot	set		a set of 78 cards, used for telling what will happen to someone in the future
+!inflammable	start		inflammable materials or substances will start to burn very easily
+!wide	open		completely open, awake, or apart
+!freephone	arrangement		an arrangement by which a company or organization pays the cost of telephone calls made to it
+!impressive	makes		something that is impressive makes you admire it because it is very good, large, important, etc
+!tempting	seems		something that is tempting seems very good and you would like to have it or do it
+!subhuman	having		not having all the qualities a normal human being has
+!capP	abbreviation		the abbreviation of

--- a/src/dep_to_4lang.txt
+++ b/src/dep_to_4lang.txt
@@ -261,6 +261,7 @@ prepc_away_from	-,-
 prepc_based_on	-,-
 prepc_because_of	-,-
 prepc_before	-,-
+prepc_but	-,-
 prepc_compared_to	-,-
 prepc_compared_with	-,-
 prepc_during	-,-

--- a/src/dict_to_4lang.py
+++ b/src/dict_to_4lang.py
@@ -1,4 +1,5 @@
 from __future__ import with_statement
+from collections import defaultdict
 from ConfigParser import ConfigParser
 #from collections import defaultdict
 import json
@@ -16,6 +17,7 @@ from utils import batches
 
 class DictTo4lang():
     def __init__(self, cfg_file):
+        self.dictionary = {}
         self.cfg_dir = os.path.dirname(cfg_file)
         default_cfg_file = os.path.join(self.cfg_dir, 'default.cfg')
         self.cfg = ConfigParser()
@@ -33,54 +35,39 @@ class DictTo4lang():
 
     def parse_dict(self):
         input_file = self.cfg.get('data', 'input_file')
-        entries = self.longman_parser.parse_file(input_file)['entries']
-        self.dictionary = dict(
-            ((entry['hw'], entry) for entry in entries))
+        self.raw_dict = defaultdict(dict)
+        for entry in self.longman_parser.parse_file(input_file):
+            self.unify(self.raw_dict[entry['hw']], entry)
+
+    def unify(self, entry1, entry2):
+        if entry1 == {}:
+            entry1.update(entry2)
+        elif entry1['hw'] != entry2['hw']:
+            raise Exception(
+                "cannot unify entries with different headwords: " +
+                "{0} vs. {1}".format(entry1['hw'], entry2['hw']))
+
+        entry1['senses'] += entry2['senses']
 
     def process_entries(self, words):
         entry_preprocessor = EntryPreprocessor(self.cfg)
-        words_to_process = []
-        for word in words:
-            preprocessed_word = entry_preprocessor.preprocess_word(word)[0]
-            if preprocessed_word != word:
-                #TODO we assume that word preprocessing will never map to
-                #existing headwords, which would now result in those entries
-                #getting overwritten
-                self.dictionary[preprocessed_word] = self.dictionary.pop(word)
-            words_to_process.append(preprocessed_word)
-
         entries = map(entry_preprocessor.preprocess_entry,
-                      (self.dictionary[word] for word in words_to_process))
+                      (self.raw_dict[word] for word in words))
 
         stanford_wrapper = StanfordWrapper(self.cfg)
         entries = stanford_wrapper.parse_sentences(entries)
 
-        """
-        to_parse = defaultdict(list)
-        for i in range(len(entries)):
-            entries[i] = entry_preprocessor.preprocess_entry(entries[i])
-
-            if entries[i]['to_filter']:
+        for entry in entries:
+            if entry['to_filter']:
                 continue
-            word = entries[i]['hw']
-            for sense in entries[i]['senses']:
-                sense['definition'] = {
-                    "sen": sense['definition'],
-                    "pos": entries[i]["pos"],
-                    "deps": []}
-                if not sense['definition']['sen'] is None:
-                    to_parse.append(sense['definition'])
 
-        stanford_wrapper = StanfordWrapper(self.cfg)
-        stanford_wrapper.parse_sentences(to_parse)
+            word = entry['hw']
+            if word in self.dictionary:
+                raise Exception(
+                    "entries with identical headwords: {0}".format(
+                        entry, self.dictionary[word]))
 
-        #this is OK as long as no two entries have the same headword field,
-        #which should be a requirement on the dictionary parser output anyway
-        """
-
-        self.dictionary.update(
-            ((entry['hw'], entry)
-                for entry in entries if not entry['to_filter']))
+            self.dictionary[word] = entry
 
     def process_entries_thread(self, i, words):
         try:
@@ -94,11 +81,11 @@ class DictTo4lang():
     def run(self, no_threads=1):
         logging.info('parsing xml...')
         self.parse_dict()
-        entries_per_thread = (len(self.dictionary) / no_threads) + 1
+        entries_per_thread = (len(self.raw_dict) / no_threads) + 1
         self.thread_states = {}
         # may turn out to be less then "no_threads" with small input
         started_threads = 0
-        for i, batch in enumerate(batches(self.dictionary.keys(),
+        for i, batch in enumerate(batches(self.raw_dict.keys(),
                                   entries_per_thread)):
 
             t = threading.Thread(

--- a/src/get_def_words.py
+++ b/src/get_def_words.py
@@ -1,0 +1,9 @@
+import sys
+from longman_parser import LongmanParser
+
+def main():
+    dictionary = LongmanParser.parse_file(sys.argv[1])
+    for entry in dictionary['entries']:
+        def_words = set()
+        for sense in entry['senses']:
+            def_words |= sense['definition']

--- a/src/get_def_words.py
+++ b/src/get_def_words.py
@@ -1,9 +1,0 @@
-import sys
-from longman_parser import LongmanParser
-
-def main():
-    dictionary = LongmanParser.parse_file(sys.argv[1])
-    for entry in dictionary['entries']:
-        def_words = set()
-        for sense in entry['senses']:
-            def_words |= sense['definition']

--- a/src/longman_parser.py
+++ b/src/longman_parser.py
@@ -67,22 +67,38 @@ class LongmanParser():
         return {"full_form": full_form, "definition": definition}
 
     @staticmethod
+    def get_headword(entry_text):
+        return LongmanParser.remove_extra_whitespace(
+            LongmanParser.get_section("HWD", entry_text))
+
+    @staticmethod
+    def get_pos(entry_text):
+        return LongmanParser.remove_extra_whitespace(
+            LongmanParser.get_section("POS", entry_text))
+
+    @staticmethod
     def parse_entry(entry_text):
-        return {
-            "hw": LongmanParser.remove_extra_whitespace(
-                LongmanParser.get_section("HWD", entry_text)),
-            "pos": LongmanParser.remove_extra_whitespace(
-                LongmanParser.get_section("POS", entry_text)),
+        entry = {
+            "hw": LongmanParser.get_headword(entry_text),
             "senses": map(
                 LongmanParser.parse_sense,
                 LongmanParser.iter_sections("Sense", entry_text)),
         }
 
+        pos = LongmanParser.get_pos(entry_text)
+        for sense in entry['senses']:
+            sense['pos'] = pos
+
+        hom_num = LongmanParser.get_section('HOMNUM', entry_text)
+        if hom_num is not None:
+            entry['hom_num'] = hom_num.strip()
+
+        return entry
+
     @staticmethod
     def parse_xml(xml_text):
-        return {"entries": map(
-            LongmanParser.parse_entry,
-            LongmanParser.iter_sections("Entry", xml_text))}
+        for raw_entry in LongmanParser.iter_sections("Entry", xml_text):
+            yield LongmanParser.parse_entry(raw_entry)
 
     @staticmethod
     def parse_file(fn):

--- a/src/longman_parser.py
+++ b/src/longman_parser.py
@@ -44,7 +44,7 @@ class LongmanParser():
     def remove_extra_whitespace(text):
         if text is None:
             return None
-        return " ".join(text.split())
+        return " ".join(text.split()).strip()
 
     @staticmethod
     def clean_definition(definition):

--- a/src/print_roots.py
+++ b/src/print_roots.py
@@ -1,0 +1,26 @@
+import json
+import re
+import sys
+
+dep_regex = re.compile("([a-z_-]*)\((.*?)-([0-9]*)'*, (.*?)-([0-9]*)'*\)")
+def main():
+    d = json.load(open(sys.argv[1]))
+    for word, entry in d.iteritems():
+        if entry['to_filter'] or not entry["senses"]:
+            continue
+        definition = entry["senses"][0]["definition"]
+        if definition is None:
+            continue
+        flags = entry["senses"][0]["flags"]
+        sen = definition["sen"]
+        for dep in definition["deps"]:
+            dep_match = dep_regex.match(dep)
+            dep, word1, id1, word2, id2 = dep_match.groups()
+            if dep == "root":
+                root_word = word2
+                break
+        print u"{0}\t{1}\t{2}\t{3}".format(
+            word, root_word, u",".join(flags), sen).encode("utf-8")
+
+if __name__ == "__main__":
+    main()

--- a/src/stanford_jython.py
+++ b/src/stanford_jython.py
@@ -1,28 +1,80 @@
+import math
+import os
 import sys
 
-
-
 sys.path.append(sys.argv[1])
- 
-from java.io import CharArrayReader
-from edu.stanford.nlp import *
- 
-lp = parser.lexparser.LexicalizedParser('edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz')
-tlp = trees.PennTreebankLanguagePack()
-lp.setOptionFlags(["-maxLength", "80", "-retainTmpSubcategories"])
- 
-sentence = 'One of my favorite features of functional programming \
-languages is that you can treat functions like values.'
- 
-toke = tlp.getTokenizerFactory().getTokenizer(CharArrayReader(sentence));
-wordlist = toke.tokenize()
- 
-if (lp.parse(wordlist)):
-    parse = lp.getBestParse()
- 
-gsf = tlp.grammaticalStructureFactory()
-gs = gsf.newGrammaticalStructure(parse)
-tdl = gs.typedDependenciesCollapsed()
- 
-print parse.toString() 
-print tdl
+
+from edu.stanford.nlp.process import Morphology, PTBTokenizer, WordTokenFactory
+from edu.stanford.nlp.parser.common import ParserConstraint
+from edu.stanford.nlp.parser.lexparser import Options
+from edu.stanford.nlp.parser.lexparser import LexicalizedParser
+from edu.stanford.nlp.ling import Sentence
+from edu.stanford.nlp.trees import PennTreebankLanguagePack
+
+from java.io import StringReader
+from java.util.regex import Pattern
+
+class StanfordParser:
+
+    def __init__(self, parser_file,
+                 parser_options=['-maxLength', '80',
+                                 '-retainTmpSubcategories']):
+
+        """@param parser_file: path to the serialised parser model
+            (e.g. englishPCFG.ser.gz)
+        @param parser_options: options
+        """
+
+        assert os.path.exists(parser_file)
+        options = Options()
+        options.setOptions(parser_options)
+        self.lp = LexicalizedParser.getParserFromFile(parser_file, options)
+        tlp = PennTreebankLanguagePack()
+        self.gsf = tlp.grammaticalStructureFactory()
+        self.lemmer = Morphology()
+        self.word_token_factory = WordTokenFactory()
+        self.parser_query = None
+
+    def tokenize(self, text):
+        reader = StringReader(text)
+        tokeniser = PTBTokenizer(reader, self.word_token_factory, None)
+        tokens = tokeniser.tokenize()
+        return tokens
+
+    def get_parse(self, sentence):
+        tokens = [unicode(x) for x in self.tokenize(sentence)]
+        parse = self.lp.apply(Sentence.toWordList(tokens))
+        return parse
+
+    def get_grammatical_structure(self, parse):
+        return self.gsf.newGrammaticalStructure(parse)
+
+    def get_kbest(self, query, k=3):
+        for candidate_tree in query.getKBestPCFGParses(k):
+            parse = candidate_tree.object()
+            prob = math.e ** candidate_tree.score()
+            yield prob, parse
+
+def main():
+    parser_file = sys.argv[2]
+    parser = StanfordParser(parser_file)
+
+    query = parser.lp.parserQuery()
+    #constraints = [ParserConstraint(0, 3, Pattern.compile("VP.*"))]
+    constraints = [ParserConstraint(0, 12, Pattern.compile("NP.*"))]
+    query.setConstraints(constraints)
+
+    sentence = 'the size of a radio wave used to broadcast a radio signal'
+
+    toks = parser.tokenize(sentence)
+    query.parse(toks)
+    parse = query.getBestParse()
+
+    gs = parser.get_grammatical_structure(parse)
+    dependencies = gs.typedDependenciesCollapsed()
+
+    print parse.pennPrint()
+    print "\n".join(map(str, dependencies))
+
+if __name__ == "__main__":
+    main()

--- a/src/stanford_parser.py
+++ b/src/stanford_parser.py
@@ -86,11 +86,11 @@ class StanfordParser:
                 if c % 100 == 0:
                     log_file.write("parsed {0} entries\n".format(c))
                     log_file.flush()
-                pos = entry['pos']
                 for sense in entry['senses']:
                     sentence = sense['definition']
                     if sentence is None:
                         continue
+                    pos = sense['pos']
                     constraints = StanfordParser.get_constraints(sentence, pos)
                     parse, _, dependencies = self.parse_with_constraints(
                         sentence, constraints)

--- a/src/stanford_parser.py
+++ b/src/stanford_parser.py
@@ -1,6 +1,8 @@
+import json
 import math
 import os
 import sys
+from tempfile import NamedTemporaryFile
 
 sys.path.append(sys.argv[1])
 
@@ -15,6 +17,15 @@ from java.io import StringReader
 from java.util.regex import Pattern
 
 class StanfordParser:
+
+    @staticmethod
+    def get_constraints(sentence, pos):
+        constraints = []
+        length = len(sentence)
+        if pos == 'n':
+            constraints.append(
+                ParserConstraint(0, length, Pattern.compile("NP.*")))
+        return constraints
 
     def __init__(self, parser_file,
                  parser_options=['-maxLength', '80',
@@ -55,26 +66,55 @@ class StanfordParser:
             prob = math.e ** candidate_tree.score()
             yield prob, parse
 
-def main():
-    parser_file = sys.argv[2]
-    parser = StanfordParser(parser_file)
+    def parse_with_constraints(self, sentence, constraints):
+        query = self.lp.parserQuery()
+        query.setConstraints(constraints)
+        query.parse(self.tokenize(sentence))
+        parse = query.getBestParse()
+        gs = self.get_grammatical_structure(parse)
+        dependencies = gs.typedDependenciesCollapsed()
+        return parse, gs, dependencies
 
-    query = parser.lp.parserQuery()
-    #constraints = [ParserConstraint(0, 3, Pattern.compile("VP.*"))]
-    constraints = [ParserConstraint(0, 12, Pattern.compile("NP.*"))]
-    query.setConstraints(constraints)
+    def parse_definitions(self, in_file, out_file):
+        with open(in_file) as in_obj:
+            entries = json.load(in_obj)
+        with NamedTemporaryFile(dir="/tmp", delete=False) as log_file:
+            for c, entry in enumerate(entries):
+                if c % 100 == 0:
+                    log_file.write("parsed {0} entries\n".format(c))
+                    log_file.flush()
+                pos = entry['pos']
+                for sense in entry['senses']:
+                    sentence = sense['definition']
+                    if sentence is None:
+                        continue
+                    constraints = StanfordParser.get_constraints(sentence, pos)
+                    parse, _, dependencies = self.parse_with_constraints(
+                        sentence, constraints)
+
+                    dep_strings = map(unicode, dependencies)
+                    sense['definition'] = {
+                        'sen': sentence,
+                        'deps': dep_strings}
+
+        with open(out_file, 'w') as out:
+            json.dump(entries, out)
+
+def test():
+    parser = StanfordParser(sys.argv[2])
 
     sentence = 'the size of a radio wave used to broadcast a radio signal'
-
-    toks = parser.tokenize(sentence)
-    query.parse(toks)
-    parse = query.getBestParse()
-
-    gs = parser.get_grammatical_structure(parse)
-    dependencies = gs.typedDependenciesCollapsed()
+    pos = 'n'
+    parse, _, dependencies = parser.parse_with_constraints(
+        sentence, StanfordParser.get_constraints(sentence, pos))
 
     print parse.pennPrint()
     print "\n".join(map(str, dependencies))
+
+def main():
+    parser_file, in_file, out_file = sys.argv[2:5]
+    parser = StanfordParser(parser_file)
+    parser.parse_definitions(in_file, out_file)
 
 if __name__ == "__main__":
     main()

--- a/src/stanford_parser.py
+++ b/src/stanford_parser.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import math
 import os
 import sys
 from tempfile import NamedTemporaryFile
 
 sys.path.append(sys.argv[1])
+sys.path.append(
+    "/home/recski/projects/stanford_dp/stanford-parser-full-2015-01-30/ejml-0.23.jar")  # nopep8
 
 from edu.stanford.nlp.process import Morphology, PTBTokenizer, WordTokenFactory
 from edu.stanford.nlp.parser.common import ParserConstraint
@@ -101,13 +104,18 @@ class StanfordParser:
             json.dump(entries, out)
 
 def test():
+    logging.warning("running test, not main!")
     parser = StanfordParser(sys.argv[2])
+
+    dv_model = parser.lp.reranker.getModel()
+    print dv_model
 
     sentence = 'the size of a radio wave used to broadcast a radio signal'
     pos = 'n'
-    parse, _, dependencies = parser.parse_with_constraints(
+    parse, gs, dependencies = parser.parse_with_constraints(
         sentence, StanfordParser.get_constraints(sentence, pos))
 
+    print type(parse), type(gs)
     print parse.pennPrint()
     print "\n".join(map(str, dependencies))
 
@@ -118,3 +126,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    #test()


### PR DESCRIPTION
The jython module now plugged into dict_to_4lang (stanford_parser.py) allows to pass custom constraints to the parser based on the POS-tag (or based on anything else later). The only data structure used is a dictionary whose keys are headwords and values are entries in the old sense. Stanford wrapper writes these to json files as is and launches the jython module, which in turn adds the dependencies and writes the json back to another file (it doesn't overwrite the original, for debugging purposes)
@pajkossy 