### PR TITLE
local path is eliminated

### DIFF
--- a/src/fourlang/lexicon.py
+++ b/src/fourlang/lexicon.py
@@ -14,6 +14,7 @@ from utils import get_cfg
 
 import networkx as nx
 import os
+import csv
 
 
 class Lexicon():
@@ -138,6 +139,7 @@ class Lexicon():
         self.stopwords.add('as')  # TODO
         self.stopwords.add('root')  # TODO
         self.full_graph = None
+        self.shortest_path_dict = None
 
     def get_words(self):
         return set(self.lexicon.keys()).union(set(self.ext_lexicon.keys()))
@@ -188,6 +190,11 @@ class Lexicon():
 
         if printname.isupper():
             return self.get_new_machine(printname)
+
+        # # TODO: hack
+        # if printname == 'have':
+        #     print "HAVE"
+        #     return self.get_machine('HAS')
 
         machines = self.lexicon.get(
             printname, self.ext_lexicon.get(
@@ -288,6 +295,22 @@ class Lexicon():
             machine = self.get_machine(word)
             MG = MachineGraph.create_from_machines([machine], str_graph=True)
             G = MG.G
+
+            # TODO: to print out all graphs
+            # try:
+            #     fn = os.path.join('/home/eszter/projects/4lang/data/graphs/allwords', u"{0}.dot".format(word)).encode('utf-8')
+            #     with open(fn, 'w') as dot_obj:
+            #         dot_obj.write(MG.to_dot_str_graph().encode('utf-8'))
+            # except:
+            #     print "EXCEPTION: " + word
+
+            # TODO: words to test have nodes
+            # if 'other' in G.nodes() and 'car' in G.nodes():
+            #     print word
+            #
+            # if word == 'merry-go-round' or word == 'Klaxon':
+            #     print G.edges()
+
             self.full_graph.add_edges_from(G.edges(data=True))
             # TODO: needed??
             # self.full_graph.add_nodes_from(G.nodes())
@@ -299,6 +322,21 @@ class Lexicon():
             #     dot_obj.write(MG.to_dot_str_graph().encode('utf-8'))
 
         return self.full_graph
+
+    def get_shortest_path(self, word1, word2, file):
+        if self.shortest_path_dict == None:
+            self.shortest_path_dict = dict()
+            with open(file, 'r') as f:
+                reader = csv.reader(f, delimiter="\t")
+                d = list(reader)
+                for path in d:
+                    key = path[0] + "_" + path[-1]
+                    self.shortest_path_dict[key] = len(path)
+        key = word1 + "_" + word2
+        if key in self.shortest_path_dict.keys():
+            return self.shortest_path_dict[key]
+        else:
+            return 0
 
 if __name__ == "__main__":
     logging.basicConfig(

--- a/src/fourlang/similarity.py
+++ b/src/fourlang/similarity.py
@@ -63,8 +63,12 @@ class WordSimilarity():
         self.log('nodes1_expand: {0}, nodes2_expand: {1}'.format(nodes1_expand, nodes2_expand))
 
         # TODO: should be machine_expand
-        sims = self.sim_feats.get_all_features(MachineInfo(machine1, nodes1, nodes1_expand, links1, links1_expand),
-                                               MachineInfo(machine2, nodes2, nodes2_expand, links2, links2_expand))
+        sims = self.sim_feats.get_all_features(MachineInfo(machine1_expand, nodes1, nodes1_expand, links1, links1_expand),
+                                               MachineInfo(machine2_expand, nodes2, nodes2_expand, links2, links2_expand))
+
+        # if sims['is_antonym'] == 1:
+        #     sims['shortest_path'] = 0
+
         return sims
 
     def lemma_similarities(self, lemma1, lemma2):
@@ -394,6 +398,10 @@ def get_test_pairs(fn):
 def main_word_test(cfg):
     from scipy.stats.stats import pearsonr
     word_sim = WordSimilarity(cfg)
+
+    machine = word_sim.lexicon.get_machine('merry-go-round')
+    links, nodes = word_sim.get_links_nodes(machine)
+
     test_pairs = get_test_pairs(cfg.get('sim', 'word_test_data'))
     sims, gold_sims = [], []
     for (w1, w2), gold_sim in test_pairs.iteritems():

--- a/src/fourlang/similarity.py
+++ b/src/fourlang/similarity.py
@@ -62,10 +62,10 @@ class WordSimilarity():
         self.log('links1_expand: {0}, links2_expand: {1}'.format(links1_expand, links2_expand))
         self.log('nodes1_expand: {0}, nodes2_expand: {1}'.format(nodes1_expand, nodes2_expand))
 
-        # TODO: should be machine_expand
         sims = self.sim_feats.get_all_features(MachineInfo(machine1_expand, nodes1, nodes1_expand, links1, links1_expand),
                                                MachineInfo(machine2_expand, nodes2, nodes2_expand, links2, links2_expand))
 
+        # TODO: we should use this way, but so far it didn't prove to be better
         # if sims['is_antonym'] == 1:
         #     sims['shortest_path'] = 0
 
@@ -399,8 +399,9 @@ def main_word_test(cfg):
     from scipy.stats.stats import pearsonr
     word_sim = WordSimilarity(cfg)
 
-    machine = word_sim.lexicon.get_machine('merry-go-round')
-    links, nodes = word_sim.get_links_nodes(machine)
+    # TODO: only testing
+    # machine = word_sim.lexicon.get_machine('merry-go-round')
+    # links, nodes = word_sim.get_links_nodes(machine)
 
     test_pairs = get_test_pairs(cfg.get('sim', 'word_test_data'))
     sims, gold_sims = [], []


### PR DESCRIPTION
In the config file of wordsim in section [similarity_machine_longman] there are two new entries:

`shortest_path_res: %(4langpath)s/data/paths/dijstra_res.txt`
`calc_shortest_path: false`

The first entry is the path to the file to where the cache data of the calculated shortest paths should be saved, and at the same time it corresponds to the file from where the cached data should be read out in case the `calc_shortest_path` flag is set to true or the path itself does not exist. 
